### PR TITLE
fix badge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/LSSTDESC/rail_dnf/branch/main/graph/badge.svg)](https://codecov.io/gh/LSSTDESC/rail_dnf)
-[![PyPI](https://img.shields.io/pypi/v/example_package?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/example_package/)
+[![PyPI](https://img.shields.io/pypi/v/example_package?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/pz-rail-dnf/)
 
 ## DNF: Directional Neighbourhood Fitting
 
@@ -72,7 +72,7 @@ ideally before the work has started, but definitely before any publication or
 posting of the work to the arXiv.
 
 ### Citing this package
-
+Users of rail_dnf can cite [De Vicente, Sanchez, & Sevilla-Noarbe](https://ui.adsabs.harvard.edu/abs/2016MNRAS.459.3078D/abstract)
 If you use this package, you should also cite the appropriate papers for each
 code used.  A list of such codes is included in the 
 [Citing RAIL](https://lsstdescrail.readthedocs.io/en/stable/source/citing.html)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/LSSTDESC/rail_dnf/branch/main/graph/badge.svg)](https://codecov.io/gh/LSSTDESC/rail_dnf)
-[![PyPI](https://img.shields.io/pypi/v/example_package?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/pz-rail-dnf/)
+[![PyPI](https://img.shields.io/pypi/v/pz-rail-dnf?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/pz-rail-dnf/)
 
 ## DNF: Directional Neighbourhood Fitting
 


### PR DESCRIPTION
PyPI badge was still pointed at the examples repo, switched to point to rail_dnf, which now displays properly

added a paper to cite to the README.md explicitly in the how to cite section
