### PR TITLE
Fix class docstrings to work with sphinx.  Note that config optiions …

### DIFF
--- a/src/rail/estimation/algos/dnf.py
+++ b/src/rail/estimation/algos/dnf.py
@@ -54,11 +54,6 @@ class DNFInformer(CatInformer):
     for estimating redshifts. It handles missing data by replacing
     non-detections with predefined magnitude limits and assigns errors accordingly.
 
-    Attributes:
-    - name (str): Identifier for the informer.
-    - config_options (dict): Configuration parameters inherited from `CatInformer`,
-      including bands, error bands, redshift column, magnitude limits, and other
-      relevant parameters.
     """
     name = 'DNFInformer'
     config_options = CatInformer.config_options.copy()
@@ -113,12 +108,6 @@ class DNFEstimator(CatEstimator):
     This class extends `CatEstimator` and predicts redshifts based on photometric.
     It supports multiple selection  modes for redshift estimation, processes missing data, and generates probability
     density functions (PDFs) for photometric redshifts.
-
-    Attributes:
-    - name (str): Identifier for the estimator.
-    - config_options (dict): Configuration parameters inherited from `CatEstimator`,
-      including redshift limits, number of bins, photometric bands, error bands,
-      magnitude limits, and selection mode for redshift estimation.
 
     Metrics (selection_mode):
     - ENF (1): Euclidean neighbourhood. It's a common distance metric used in kNN (k-Nearest Neighbors) for photometric redshift prediction.


### PR DESCRIPTION
…are automatically added to RailStage class docstrings and don't need to be given explicitly

## Problem & Solution Description (including issue #)

Sphinx is really picking about indentation.  Also, RailStage config_options are automatically included in class docstrings, and don't need to be added explicitly, so it is save to remove the lines that I'm suggesting to remove there.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
