### PR TITLE
fixed bug that required rail_base>2.0.0 to >=2.0.0-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-dependencies = ["pz-rail-base>2.0.0", "qp-prob[full]", "scikit-learn"]
+dependencies = ["pz-rail-base>=2.0.0-dev", "qp-prob[full]", "scikit-learn"]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]

--- a/src/rail/estimation/algos/dnf.py
+++ b/src/rail/estimation/algos/dnf.py
@@ -735,6 +735,6 @@ def compute_pdfs_fit(photoz, photozerr, zgrid):
     pdfs = norm_factor * np.exp(exponent)
 
     # Normalization using numerical integration
-    pdfs /= np.trapz(pdfs, zgrid, axis=1)[:, None]
+    pdfs /= np.trapezoid(pdfs, zgrid, axis=1)[:, None]
 
     return pdfs


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
- fixed requirement for rail-base to be >=2.0.0-dev instead of >2.0.0


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
